### PR TITLE
Putting TAC under separate version control

### DIFF
--- a/current-tac-version.js
+++ b/current-tac-version.js
@@ -1,0 +1,1 @@
+module.exports = require('./package.json').version

--- a/mediatool-terms-and-conditions.jade
+++ b/mediatool-terms-and-conditions.jade
@@ -1,0 +1,133 @@
+h1 Terms and Conditions
+p Version 1.3.0, Updated 21 May 2018
+h3
+  | These Standard Terms and Conditions are applicable by reference in the document in which Mediatool World W AB, reg. no. 556790-6689, Hammarbyterassen 10, 120 63 Stockholm, Sweden, and the Customer agree on the commercial terms for the Customer’s use of the Service, (the “Order Confirmation”). In case of any discrepancy between these Standard Terms and Conditions and the Order Confirmation, the Order Confirmation shall prevail.
+h3 1 DEFINITIONS AND INTERPRETATION
+p
+  | Definitions Capitalized terms shall have the following meanings: “Business Day(s)” means days when commercial banks are open for general banking business (other than Internet banking) in Sweden; “Consultancy Fee” means a fee paid by the hour as set out in section 1.1 in the Order Confirmation. “Critical Maintenance” means correction of critical software faults and hardware failure including security patches on third party applications; “Customer” means the party set out in the Order Confirmation, other than Mediatool; “Customer Agreement” means the Order Confirmation together with these Standard Terms and Conditions; “Customer Data” means Customer’s information which is recorded and stored when using the Service as well as the processed information which is the result of the use of the Service; “Day(s)” means calendar days unless otherwise expressly stated; “Effective Date” means the date when the Order Confirmation is signed by both parties; “Order Confirmation” means what is set out in the preamble to these Standard Terms and Conditions; “Service Fee” means an quarterly fee for the use of the Service as set out in section 1.1 in the Order Confirmation; “Software” means all software incorporated in the Service; “Standard Terms and Conditions” means this document; “Term” means the duration of the Customer Agreement as set out in the Order Confirmation; “Updates” means any planned modification to the Service done by Mediatool such as updates and new releases of Software; and “User Account” means a user account supplied by Mediatool and required in order to gain access to the Service, including any login information and security methods or other information regarding the User Account provided by Mediatool to the Customer.
+h3 2 SCOPE &ndash; GRANT OF USE
+p
+  | 2.1 Mediatool grants to the Customer a non-exclusive, world-wide, non-transferable, non-sub licensable right to use the Service through User Accounts, including any Updates, solely for the internal business purposes of the Customer during the Term.
+p
+  | 2.2 The right to use the Service is limited to the number of User Accounts acquired by the Customer. Each User Account may only be used by the physical person registered to the User Account at Mediatool.
+p
+  | 2.3 Mediatool will use their reasonable commercial efforts in order to provide, at the Customers written request, modifications and developments to the Service against Consultancy Fees.
+p
+  | 2.4 The Customer shall have the right to allow its sub-contractors to access and to use the Service to the extent necessary for the internal business purposes of the Customer, provided i) that such sub-contractors are approved in writing by Mediatool, that ii) such sub-contractors are bound by obligations of confidentiality in writing which are at least equal to the terms of the Customer Agreement and iii) that the Customer remains fully liable and responsible towards Mediatool for any actions of such sub-contractors.
+p
+  | 2.5 The Customer acknowledges and agrees that certain parts, functionality, information and material in the Service may (i) be provided by third parties, (ii) contain links to third party website and services or (iii) require importation or exportation of data from and to third party websites and services, including third party advertising platforms ("Third Party Content"). Third Party Content is not under Mediatool's control, and Mediatool expressly excludes any liability for Third Party Content. Third Party Content is subject to the terms and conditions applicable to such Third Party Content, and the Customer is solely responsible for reviewing and accepting such terms and conditions.
+h3 3 GENERAL OBLIGATIONS OF THE CUSTOMER
+p
+  | 3.1 The Customer undertakes to (a) Follow instructions and specifications given from time to time by Mediatool on their website (www.mediatool.com) and/or otherwise in writing relating to software, hardware and communication used in connection with the Service; (b) refrain from making any security and/or capacity tests of the Service without the prior written approval of Mediatool; (c) make sure that the data entered into the Service is in the agreed format, virus-free, and not in any other way capable of damaging or negatively affecting Mediatool’s systems; (d) not (whether by itself or through any third party) copy, modify, create a derivative work of, reverse engineer, reverse assemble or otherwise attempt to discover any source code or sell, assign, sublicense or otherwise assign or transfer any right in the Service; (e) not use an automated software program, spider, web-crawler, URL checker, computer “robot” or other program to access the Service without the express written consent of Mediatool (f) use the Services via the interface provided by Mediatool for accessing the Service; and (g) inform Mediatool promptly of any program errors in the Software, known or suspected security breaches and other malfunction of the Service and provide Mediatool with reasonable assistance in order for Mediatool to be able to fulfil its obligations under the Customer Agreement.
+p
+  | 3.2 The Service may include functionality that enables the Customer to post, upload or otherwise submit Customer Data and other content to the Service, including, but not limited to, text, movies, images, pictures, audio and designs (hereinafter collectively referred to as the “Content”).
+p
+  | 3.3 By posting, uploading or otherwise submitting Content, the Customer represent and warrant that it has the right to post, upload and submit such Content and that such Content (or any part thereof), including the use by Mediatool as contemplated by the Customer Agreement, does not violate any agreement, applicable law or third party right, including intellectual property rights, right of privacy and/or applicable data protection legislation. Moreover, you agree to indemnify and hold Mediatool harmless from any third party claim arising from or relating to Mediatool's use of Content as contemplated by the Customer Agreement. Mediatool reserves the right to delete or remove any Content that, in Mediatool's reasonable opinion, violates applicable laws or third party rights.
+p
+  | 3.4 By posting, uploading or otherwise submitting Content to Mediatool, the Customer grants to Mediatool a non-exclusive, non-transferrable, non-sub-licensable, fully paid license to use the Content (and any part thereof) solely in the way contemplated by the Customer Agreement or as is otherwise necessary for Mediatool's performance of any contractual right or obligation in relation to you.
+p
+  | 3.5 The Service may contain functionality for inviting third parties to subscribe and/or use the Service. If the Customer decides to use such functionality, the Customer hereby acknowledge and agree that it is responsible for obtaining any necessary consent from the recipient of the invitation, and that Mediatool may reproduce the Customer's contact information and trademarks when disclosing the sender of such invitations.
+p
+  | 3.6 The Customer understands and agrees that it is solely responsible and liable for any losses, damages and/or third party claims arising from or relating to the Customer's use of the Content. Mediatool shall not in any way or form be responsible or liable for such use.
+p
+  | 3.7 The Customer agrees to indemnify, hold harmless and defend Mediatool from and against all claims, defense costs (including attorneys’ fees), judgments, settlements and other expenses arising out of alleged facts or circumstances that, if true, would constitute a breach of the Customer’s obligations according to the Customer Agreement.
+p
+  | 3.8 If the Customer violates any term or condition of the Customer Agreement, Mediatool has the right to suspend or terminate the Customer's access to the Service (or parts thereof).
+h3 4 PRICES AND TERMS OF PAYMENT
+p
+  | 4.1 Fees for goods and services provided under the Customer Agreement, including the Service Fee, are specified in the Order Confirmation and are fixed for a period of twelve (12) months from the Effective Date, whereafter Mediatool reserves the right to change any fees.
+p
+  | 4.2 The Customer may choose between a monthly or annual subscription, whereas monthly subscriptions may be terminated by either party at least one (1) month prior to the end of the then-current subscription period and annual subscriptions may be terminated by either party at least three (3) months prior to the end of the then-current subscription period. Termination shall be made by the Customer by visiting the subscriptions settings page and cancel their subscription within the software if the Customer are paying by card. Termination shall be made by the Customer via email to <a href="mailto:info@mediatool.com">info@mediatool.com</a> if the Customer is paying by invoice. Unless the Customer terminates the subscription by following Mediatool's instructions before the end of each subscription period, Mediatool has the right, but not the obligation, to renew the subscription at the end of each subscription period and charge the payment method chosen by the Customer.
+p
+  | 4.3 If the Customer has chosen to pay the Service Fee via debit or credit card, the Customer shall ensure that the balance covers the Service Fee before the end of each subscription period. Payment via debit or credit card will be done via a third party payment provider and be subject to the terms and conditions of such third party payment provider. If the Customer's card cannot be charged, the Customer's access to the Service will cease automatically, until the Service Fee has been paid in full.
+p
+  | 4.4 If the Customer has chosen that the Service Fee shall be invoiced by Mediatool, Mediatool will invoice the Service Fee in advance within fifteen (15) days of the start of each calendar month or calendar year (as applicable). Any additional fees, i.e. Consultant Fees, will be invoiced quarterly in arrears. Invoices shall be paid within fifteen (15) days after the invoice date of each invoice.
+p
+  | 4.5 All amounts are given exclusive of any value added tax. Any payments to be made by the Customer under the Customer Agreement shall be made net of all deductions, withholdings or taxes of any kind. Should any payment from the Customer to Mediatool, for any reason, be subject to any deductions, withholdings, or taxes, the agreed amount of payment shall be grossed up by the amount of such deductions, withholdings, or taxes in order for the sum receivable by Mediatool shall be the agreed amount of payment under the Customer Agreement before such deductions, withholding, or taxes. Upon Mediatool's request, the Customer shall provide Mediatool with VAT numbers and other information as reasonably required for Mediatool's invoicing of the Service Fee.
+p
+  | 4.6 In the event that the Customer at any time should fail to timely make any payment under the Customer Agreement in full on the due date, Mediatool shall be entitled to interest on the amount overdue until payment is made at a rate of the Swedish base rate (Sw. referensränta) plus eight (8) percentage points.
+h3 5 Refund policy
+p
+  | 5.1 Mediatool has a NO REFUND policy. All sales are final. There are no refunds.
+p
+  | 5.2 Any downgrade in the Service use will result in the new applicable Service Fee being charged at the next billing cycle. There will be no prorating for downgrades in between billing cycles. Downgrading the Service may cause the loss of features or capacity of the Customer's user account. Mediatool does not accept any liability for such loss.
+h3 6 SUPPORT, MAINTENANCE AND UPDATES
+h4 Support
+p
+  | Mediatool and its IT-support function shall be available during Business Days between the hours of 9 AM – 4.30 PM CET, to provide technical assistance by telephone or e-mail.
+h4 Updates
+p
+  | 6.2 2 Mediatool reserves the right to, at its sole discretion, Update the Service to the extent Mediatool deems necessary. Mediatool shall, if possible, schedule any downtime to the Service due to Update between 5 PM – 9 AM CET weekdays or during weekends. Mediatool shall inform the Customer seven (7) Days in advance of any such Updates. To receive such notification the customer need to specify an e-mail address to receive such information to.
+h4 Critical Maintenance
+p
+  | 6.3 Should Critical Maintenance be required, it is expected that Mediatool should not seek permission for system outage or loss of service but whenever possible Mediatool will provide reasonable notice. Best endeavors will be made by Mediatool to limit effects of Critical Maintenance.
+h3 7 CUSTOMER DATA AND PERSONAL DATA
+p
+  | 7.1 The Customer shall retain all rights to the Customer Data and Content. Unless otherwise expressly agreed in writing, no rights or ownership of Customer Data or Content, or part thereof, shall be transferred to Mediatool under the Customer Agreement.
+p
+  | 7.2 Mediatool undertakes to store Customer Data and other Content during Term, and shall endeavor to make daily backups thereof. Notwithstanding the foregoing, Mediatool neither represents nor warrants that data losses will not occur, and the Customer is advised to regularly backup Customer Data and other Content to avoid data losses.
+p
+  | 7.3 By registering a User Account, accessing or using the Service or Mediatool's website, the Customer agrees to Mediatool's processing of personal data in accordance with our #[a(href="/cookies") Privacy Policy]. Furthermore, the Customer represents and warrants that any individual authorized to use the Services on the Customer's behalf has read Mediatool's Privacy Policy and provided any and all necessary consents for Mediatool's processing of personal data in accordance therewith.
+p
+  | 7.4 By registering a User Account, the Customer further acknowledges and agrees that Mediatool will send emails outlining the features of the Service, as well as advise and instructions on how to better take advantage of the same, to the email address provided by the Customer during the registration procedure. Should the Customer want to opt out of recieving these emails the Customer can do so at any time by contacting Mediatool.
+p
+  | 7.5 Upon the expiration or termination of the Customer Agreement, Mediatool undertakes to make stored Customer Data and other Content belonging to the Customer available to the Customer for a commercially reasonable fee for a period of thirty (30) days after the expiration or termination of this Agreement.
+p
+  | 7.6 By registering a User Account, the Customer acknowledges that Mediatool stores the Customer email address. Mediatool uses the Customer email address as user name when logging in to the Software. The Customer can on its own discretion add or delete personal information such as first name, last name and telephone number to for example enhance the communication experience between colleagues using the Software. Mediatool will handle this personal information in accordance to our #[a(href="/cookies") Privacy Policy]. Should the Customer wish to be completely removed from the Software the Customer can contact Mediatool directly and Mediatool will make the arrangements to remove the Customer from the Software.
+h3 8 INTELLECTUAL PROPERTY RIGHTS
+p
+  | 8.1 The Customer acquires only user rights to the Service, and any Update and/or subsequent change thereto, in accordance with the Customer Agreement. Mediatool retains all intellectual property rights incorporated in or relating to the Service, including any subsequent developments (including any translations, or derivatives thereof, even if unauthorized) or changes thereto.
+p
+  | 8.2 Mediatool shall be entitled to use the Customer’s name (including logo and trademarks) as a customer reference in marketing materials and on Mediatool's website.
+p
+  | 8.3 In the event of a claim from a third party that the Customers’ use of the Service is infringing any intellectual property right held by a third party the following shall apply.
+p
+  | 8.4 Mediatool shall, at its own discretion i) procure the right to continued use of the Service for the Customer, ii) modify the Service so that it no longer infringes, or iii) cancel the Customers use of the Service, in which case Mediatool shall be obligated to compensate the Customer for any direct damages but always subject to the limitation of liability stated in section 9.2.
+p
+  | 8.5 What is stated in this section 9 shall constitute Mediatool’s entire responsibility for infringements in third party rights. Infringements by third parties
+p
+  | 8.6 The Customer shall, as soon as possible, notify Mediatool of any infringement or suspected infringement of Mediatool’s intellectual property rights. Mediatool is however not obliged to defend such rights. If Mediatool chooses to defend its rights, the Customer shall at its own expense and to a reasonable extent assist Mediatool. For the avoidance of doubt, the Customer shall not be obliged to incur any external legal costs in relation to such dispute but shall only provide assistance from its own staff to Mediatool and its legal counsel.
+h3 9 LIMITATION OF LIABILITY
+p
+  | 9.1 The Service is supplied “as is”, "as available" and, except as set forth in writing herein, Mediatool makes no warranties or guarantees, either expressed or implied, oral or written, with respect to the Service including without limitation any implied warranty of merchantability or fitness for a particular purpose. The provisions in section 6 states Mediatool’s entire responsibility with respect to defects or deficiencies related to the Service.
+p
+  | 9.2 Mediatool’s liability for damages from any cause whatsoever, and regardless of the form of action or the cause of action, shall not exceed the amounts actually received by Mediatool from the Customer pursuant to the Customer Agreement during the twelve (12) months preceding the time the cause of action arose.
+p
+  | 9.3 In no event shall Mediatool be liable to the Customer for indirect or consequential damages, regardless of the form of action therefore, including negligence, including, without limitation, damages or loss to equipment, loss of goodwill, increased expenses of operation, cost of capital, or the claims of third parties including customers of Customer, howsoever caused, regardless of whether such party has been informed of the possibility of such damages.
+h3 10 TERM AND TERMINATION
+p
+  | 10.1 The Customer Agreement shall commence on the Effective Date and shall remain in effect during the Term.
+p
+  | 10.2 Without prejudice to any remedy Mediatool may have against the Customer for breach or non-performance of the Customer Agreement, Mediatool shall have the right to terminate the Customer Agreement forthwith by giving the Customer notice in writing (a) if the Customer commits a breach of any provisions in the Customer Agreement and such breach is not capable of remedy or, being capable of remedy does not remedy such breach within fourteen (14) Days of receiving written notice to do so; or (b) if the Customer should enter into liquidation, either voluntary or compulsory, or be-come insolvent or enter into composition or corporate reorganization proceedings or if execution be levied on any goods and effects of the other party or the other party should enter into receivership.
+p
+  | 10.3 In addition to the right of termination in accordance with section 10.2 above, Mediatool reserves the right to temporary suspend the Customers access to the Service if the Customer fails to make payments to Mediatool as stipulated in the Customer Agreement and fails to rectify such debts within a period of fourteen (14) days after the due date of the payment.
+h3 11 CONFIDENTIALITY UNDERTAKINGS
+p
+  | 11.1 The Parties undertake that they will not reveal to third parties, nor use for any other purpose than fulfilling their respective obligations under the Customer Agreement, any confidential information which they obtain from the other party during the Term. Confidential information shall mean information which is designated in writing or orally as being confidential or which should otherwise be reasonably deemed to be confidential, given the nature of the in-formation or the manner of its disclosure. The Customer is aware that Mediatool, without limitation, regards the commercial contents of the Customer Agreement to be strictly confidential. Mediatool is aware that Customer Data is considered to be confidential information by the Customer.
+p
+  | 11.2 Section 11.1 does not apply to information (a) which is or becomes publicly known in any other manner that by a breach of this confidentiality undertaking; or (b) which is required to be disclosed due to a court order, a decision by a public authority or otherwise according to mandatory law.
+p
+  | 11.3 Notwithstanding the foregoing, the receiving Party may disclose confidential information to reliable employees, professional advisers or sub-contractors, to the extent necessary for its work, provided that such persons are bound by obligations of confidentiality in writing and non-use to receiving Party which are at least equal to the terms of the Customer Agreement. The receiving Party shall ensure that such persons be fully aware of the obligations of the Customer Agreement and shall remain fully responsible for any breach of these provisions by its employees, professional advisers or sub-contractors.
+p
+  | 11.4 The obligations under this section 11 shall survive the termination and/or expiration of the Customer Agreement.
+h3 12 FORCE MAJEURE
+p
+  | 12.1 Mediatool is relieved from liability for failure to perform any of its obligations under this Customer Agreement, due to any circumstances beyond its immediate control, which impedes, delays, or aggravates any such obligation, such as changes in laws and regulations or the interpretation thereof, acts of authorities, war, acts of war, terrorism, acts of terrorism, acts of God, perils of the sea or air; fire, flood, drought, explosion, sabotage, accident, embargo, riot, civil commotion, shortage of supplies, equipment, materials, breakdown of equipment, labour disputes, blockades, major accidents and currency restrictions. Mediatool shall also be relieved from all liabilities in the case of a labour dispute in which Mediatool is a party and for damages attributable to suppliers of infrastructure, such as data or telecommunication, or other third parties that are not under the control of Mediatool.
+h3 13 MISCELLANEOUS
+h4 Notices
+p
+  | 13.1 Unless otherwise provided in the Customer Agreement, any notice shall be in writing and shall be sufficiently given if delivered personally, or if transmitted by e-mail where the other party confirms the recipient of such e-mail by a reply, or if transmitted by facsimile with an original signed copy delivered personally within twenty-four hours thereafter, or four Days after mailed by prepaid registered post addressed to parties at their respective addresses set forth in the Order Confirmation or at such other address as is specified by no-tice.
+h4 Assignment
+p
+  | 13.2 The Customer may not assign, novate or transfer any of its rights or obligations under the Customer Agreement to a third party without the prior written consent of Mediatool.
+h4 Sub suppliers
+p
+  | 13.3 Mediatool shall be entitled to engage sub suppliers to fulfil its undertakings towards the Customer, provided that Mediatool remains liable for the performance of the contractual obligations performed by the sub-contractors as if they were performed by Mediatool.
+h4 Entire agreement
+p
+  | 13.4 The Customer Agreement constitutes the entire arrangement and understanding between the Parties and supersedes and extinguishes all prior agreements, negotiations and discussions relating to the subject matter of the Customer Agreement, whether written or verbal. Any changes to the Customer Agreement shall be made only through a written document signed by both Parties.
+h4 Governing law and disputes
+p
+  | 13.5 The Customer Agreement shall be construed in accordance with and be governed by the laws of Sweden, excluding its principles of conflicts of law.
+p
+  | 13.6 Any dispute, controversy or claim arising out of or in connection with the Customer Agreement, or the breach, termination or invalidity thereof, shall be settled by Swedish courts with Stockholm district court as the court of first instance.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@mediatool/mt-tac",
+  "version": "1.3.0",
+  "description": "Mediatool terms and conditions",
+  "main": "current-tac-version.js"
+}


### PR DESCRIPTION
To be able to get the latest version of the mediatool terms and conditions
both in the backend, frontend and webpage.